### PR TITLE
Force reload of the current station on playback start to ensure that …

### DIFF
--- a/RadioSpiral/AppDelegate.swift
+++ b/RadioSpiral/AppDelegate.swift
@@ -94,6 +94,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // Add handler for Play Command
         commandCenter.playCommand.addTarget { event in
+            StationsManager.shared.reloadCurrent()
             FRadioPlayer.shared.play()
             return .success
         }

--- a/RadioSpiral/Model/StationsManager.swift
+++ b/RadioSpiral/Model/StationsManager.swift
@@ -91,6 +91,15 @@ class StationsManager {
         player.radioURL = URL(string: station.streamURL)
     }
     
+    // Exists because with Azuracast, resuminh from stop/pause is not working
+    // consistently, but "previous" or "next" DOES properly restart play.
+    // Will add this into the play() function and see if it helps.
+    func reloadCurrent() {
+        guard let index = getIndex(of: currentStation) else { return }
+        currentStation = stations[index]
+        player.radioURL = URL(string: currentStation!.streamURL)
+    }
+    
     func updateSearch(with filter: String) {
         searchedStations.removeAll(keepingCapacity: false)
         searchedStations = stations.filter { $0.name.range(of: filter, options: [.caseInsensitive]) != nil }

--- a/RadioSpiral/ViewControllers/NowPlayingViewController.swift
+++ b/RadioSpiral/ViewControllers/NowPlayingViewController.swift
@@ -185,6 +185,7 @@ class NowPlayingViewController: UIViewController {
             player.stop()
         } else {
             ACWebSocketClient.shared.connect()
+            _ = StationsManager.reloadCurrent(StationsManager.shared)
             player.play()
         }
     }


### PR DESCRIPTION
…it always works

The play() function only sometimes properly restarts play, but in the lockscreen, previous/next (with the single station) always properly reload the station and resume play. Rather that screw around with debugging the issue any further, I've chosen to force a reselect of the station on a play(), which (so far) seems to properly reinitialize the player and restart the music with a single tap of the control, *as it should*.